### PR TITLE
Fixed an issue with some Bartender4 buttons not being greyed out

### DIFF
--- a/GreyOnCooldown.lua
+++ b/GreyOnCooldown.lua
@@ -219,7 +219,7 @@ end
 
 -- Function to reconfigure all BT4Buttons when Bartender4 ActionBars are loaded or modified
 function GreyOnCooldown:HookBartender4GreyOnCooldownIcons()
-	for i = 1, 120 do
+	for i = 1, 180 do
 		local button = _G["BT4Button"..i]
 		if ((button ~= nil) and (not GreyOnCooldown.Bartender4ButtonsTable[i])) then
 			GreyOnCooldown.Bartender4ButtonsTable[i] = button


### PR DESCRIPTION
Hello there!
While playing I saw an issue that occurred between this addon and Bartender4. Some buttons would simply not be greyed out when on cooldown, meanwhile others would. This is not an issue that I encountered testing the Blizzard action bars.

The issue seems to stem from the fact that the loop responsible for hooking the Bartender4 buttons loops 120 times. Meanwhile, the number in "BT4ButtonX" name go up to 180 (at least as far as I've been able to observe - I'm unable to confirm whether it can go any higher). So buttons named for example "BT4Button180" would be left out and not greyed out.
![image](https://github.com/millanzarreta/GreyOnCooldown/assets/58700826/99fc6b59-5eb8-4f9e-96db-cedd4ccc617d)

I've made the change to loop 180 times total instead and tested it with all other addons besides Bartender and this addon disabled and the change seems to work perfectly now and it includes buttons that were previously skipped.

Please note I made no changes to the Classic, Tbc and Wotlk versions of the game since I can't test them currently.


